### PR TITLE
[hotfix][minor] make sure bootstrap uses both master and nodes

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: nodes
+- hosts: master,nodes
   become: true
   become_user: root
   tasks: []


### PR DESCRIPTION
Previously was referencing "nodes" which doesn't include the master.