### PR TITLE
Fix missing default VM disk device for docker storage driver configuration

### DIFF
--- a/roles/openshift-ansible-bootstrap/defaults/main.yml
+++ b/roles/openshift-ansible-bootstrap/defaults/main.yml
@@ -4,3 +4,4 @@ thinpool_volume_group_name: docker
 thinpool_logical_volume_name: thinpool
 docker_thinpool_name: "{{ thinpool_volume_group_name }}-{{ thinpool_logical_volume_name }}"
 setup_thinpool: true
+vm_disk_device: vdb


### PR DESCRIPTION
Looks like a default became missing during the refactor for the Ansible galaxy-based VM installation.

fixes #18