### PR TITLE
[minor] use contemporary variable name openshift_deployment_type

### DIFF
--- a/inventory/example_openshift-ansible/vanilla.inventory
+++ b/inventory/example_openshift-ansible/vanilla.inventory
@@ -13,7 +13,7 @@ etcd
 ansible_ssh_user=centos
 ansible_become=yes
 debug_level=2
-deployment_type=origin 
+openshift_deployment_type=origin 
 # openshift_release=v3.6
 openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
 ansible_ssh_private_key_file=/root/.ssh/id_vm_rsa


### PR DESCRIPTION
Was previously `deployment_type` in a single example inventory.