### PR TITLE
Enables the use of Fedora for OpenShift-Ansible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ inventory/*
 !inventory/example_virtual_atomic
 !inventory/example_baremetal
 !inventory/example_openshift-ansible
+!inventory/example_fedora
 roles/redhat-nfvpe.vm-spinup

--- a/README.md
+++ b/README.md
@@ -287,3 +287,23 @@ bootstrapped environment.
 
 More information about deploying OpenShift can be found on Doug's blog at 
 http://dougbtv.com//nfvpe/2017/07/18/openshift-ansible-lab-byo/
+
+## Executing an OpenShift-Ansible deployment to Fedora boxes
+
+With Fedora, you'll need to use [Ansible with Python 3](http://docs.ansible.com/ansible/latest/python_3_support.html).
+
+On your virthost (or wherever you run openshift-ansible from), make 
+sure you have Python 3 (3.5 or greater), for example if you're using a 
+CentOS 7 virthost and running your openshift-ansible playbooks there,
+you might install python and test it like so:
+
+```
+$ yum install python36
+$ ansible-playbook -i fedora.inventory sample.yaml -e 'ansible_python_interpreter=/usr/bin/python3.6'
+```
+
+You could then execute the openshift-ansible playbooks like:
+
+```
+$ ansible-playbook -i fedora.inventory playbooks/prerequisites.yml -e 'ansible_python_interpreter=/usr/bin/python3.6'
+```

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -2,6 +2,17 @@
 - hosts: master,nodes
   become: true
   become_user: root
+  gather_facts: False
+  tasks:
+    # Fedora cloud image doesn't come with Python by default, so...
+    # https://trello.com/c/XaiXEocS/239-bz-to-track-adding-python-to-the-fedora-cloud-images
+    - name: install python2 and dnf stuff
+      raw: (dnf -y install python-dnf python2-dnf libselinux-python)
+      when: host_type == "fedora"|default("centos")
+
+- hosts: master,nodes
+  become: true
+  become_user: root
   tasks: []
   roles:
     - { role: openshift-ansible-bootstrap }

--- a/inventory/example_fedora/extra-vars.yml
+++ b/inventory/example_fedora/extra-vars.yml
@@ -1,0 +1,26 @@
+---
+virtual_machines:
+  - name: openshift-master
+    node_type: master
+    system_ram_mb: 24576
+    system_cpus: 4
+  - name: openshift-node-1
+    node_type: nodes
+    system_ram_mb: 24576
+    system_cpus: 4
+  - name: openshift-node-2
+    node_type: nodes
+    system_ram_mb: 24576
+    system_cpus: 4
+host_type: fedora
+centos_genericcloud_url: https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2
+image_destination_name: Fedora-x86_64-GenericCloud.qcow2
+images_directory: /home/images
+bridge_name: br0
+bridge_networking: true
+bridge_physical_nic: enp1s0f1
+bridge_network_name: br0
+bridge_network_cidr: 192.168.1.0/24
+spare_disk_size_megs: 20480
+spare_disk_location: /var/lib/libvirt/images
+increase_root_size_gigs: 35

--- a/inventory/example_fedora/inventory
+++ b/inventory/example_fedora/inventory
@@ -1,0 +1,34 @@
+# Setup this host first, and put the IP here.
+virt_host ansible_host=192.168.1.42 ansible_ssh_user=root
+
+# After running the virt-host-setup, then change these to match.
+openshift-master ansible_host=192.168.1.184
+openshift-node-1 ansible_host=192.168.1.148
+openshift-node-2 ansible_host=192.168.1.158
+
+[virthosts]
+virt_host
+
+[nodes]
+openshift-master
+openshift-node-1
+openshift-node-2
+
+[nodes:vars]
+ansible_ssh_user=centos
+ansible_ssh_private_key_file=/home/doug/.ssh/id_openshift_hosts
+
+[all]
+virt_host
+openshift-master
+openshift-node-1
+openshift-node-2
+
+[all:vars]
+ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+vm_disk_device=vdb
+vm_disk_device_gluster=vdc
+openshift_ansible_repo=https://github.com/openshift/openshift-ansible
+openshift_ansible_version=master
+# openshift_ansible_repo=https://github.com/dougbtv/openshift-ansible.git
+# openshift_ansible_version=asb

--- a/roles/openshift-ansible-bootstrap/defaults/main.yml
+++ b/roles/openshift-ansible-bootstrap/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+host_type: centos
 domain_name: example.local
 thinpool_volume_group_name: docker
 thinpool_logical_volume_name: thinpool

--- a/roles/openshift-ansible-bootstrap/tasks/docker_setup.yml
+++ b/roles/openshift-ansible-bootstrap/tasks/docker_setup.yml
@@ -1,0 +1,106 @@
+# vim: set tabstop=2 shiftwidth=2 expandtab ft=yaml :
+---
+- name: Stop docker
+  service:
+    name: docker
+    state: stopped
+  ignore_errors: yes
+
+- name: start NetworkManager
+  service:
+    name: NetworkManager
+    state: started
+    enabled: yes
+
+- name: Install docker from default repo
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - docker
+
+- name: Setup volumes and the thinpool
+  block:
+    - name: Get current volume groups
+      command: >
+        vgdisplay
+      register: vg_list
+
+    - name: Get current physical volumes
+      command: >
+        pvdisplay
+      register: pv_list
+
+    - name: Get current logical volumes
+      command: >
+        lvdisplay
+      register: lv_list
+
+    - name: Create physical volume
+      command: >
+        pvcreate /dev/{{ vm_disk_device }}
+      when: "vm_disk_device not in pv_list.stdout"
+
+    - name: Create volume group
+      command: >
+        vgcreate docker /dev/{{ vm_disk_device }}
+      when: "'docker' not in vg_list.stdout"
+
+    - name: Create thinpool logical volumes
+      command: >
+        lvcreate --wipesignatures y -n {{ item.name }} docker -l {{ item.percent }}%VG
+      when: "'thinpool' not in lv_list.stdout"
+      with_items:
+        - name: thinpool
+          percent: 95
+        - name: thinpoolmeta
+          percent: 1
+
+    - name: Convert volumes to a thin pool
+      command: >
+        lvconvert -y
+        --zero n
+        -c 512K
+        --thinpool docker/thinpool
+        --poolmetadata docker/thinpoolmeta
+      when: "'LV Pool metadata' not in lv_list.stdout"
+      register: lvconvert_result
+
+    - name: Template thinpool.profile
+      template:
+        src: docker-thinpool.profile.j2
+        dest: /etc/lvm/profile/docker-thinpool.profile
+
+    - name: Apply the LVM profile
+      command: >
+        lvchange --metadataprofile docker-thinpool docker/thinpool
+      when: lvconvert_result.changed
+
+    - name: Always apply LVS monitoring
+      command: >
+        lvs -o+seg_monitor
+  when: setup_thinpool
+
+- name: Template Docker's daemon.json
+  template:
+    src: daemon.json.j2
+    dest: /etc/docker/daemon.json
+  when: host_type == "centos"
+
+- name: Start and enable docker
+  service:
+    name: docker
+    enabled: yes
+    state: started
+
+- name: Check docker info
+  command: >
+    docker info
+  register: docker_info
+  tags:
+    - skip_ansible_lint # skipping ANSIBLE0012 because we always want to check
+
+- name: Fail when docker info shows a loopback device
+  fail:
+    msg: "Looks like there's still a loopback device in play with docker storage."
+  when: "'loop' in docker_info.stdout"

--- a/roles/openshift-ansible-bootstrap/tasks/fedora.yml
+++ b/roles/openshift-ansible-bootstrap/tasks/fedora.yml
@@ -1,9 +1,13 @@
 ---
-- name: install pre-reqs (CentOS)
+- name: install pre-reqs (Fedora)
   package:
     name: "{{ item }}"
     state: present
   with_items:
+    - dbus-python
+    - PyYAML
+    - python-ipaddress
+    - yum-utils
     - device-mapper-persistent-data
     - lvm2
     - NetworkManager

--- a/roles/openshift-ansible-bootstrap/tasks/main.yml
+++ b/roles/openshift-ansible-bootstrap/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
 - include_tasks: hostname_setup.yml
 - include_tasks: centos.yml
-  when: host_type == "centos"|default("centos")
+  when: host_type == "centos"
+- include_tasks: fedora.yml
+  when: host_type == "fedora"
+- include_tasks: docker_setup.yml
+  when: host_type != "atomic"

--- a/virt-host-setup.yml
+++ b/virt-host-setup.yml
@@ -1,6 +1,12 @@
 ---
 - hosts: virthosts
   tasks: []
+  pre_tasks:
+    - name: Install python36 on virt host
+      package:
+        name: python36
+        state: present
+      when:
   roles:
     - { role: redhat-nfvpe.vm-spinup }
     - { role: openshift-ansible-deps }


### PR DESCRIPTION
Some enhancements to enable the use of Fedora. Some mild refactoring 

* Uses the existing handler scheme for Atomic vs. CentOS to add Fedora
  * In particular, breaks out CentOS vs Fedora deps, and then uses a common docker install play
* Includes a "python bootstrap" method for installing Python on Fedora cloud images
* Adds Fedora examples
* Includes a README blurb on using Fedora
* Add a default variable in the bootstrap role to default to CentOS