### PR TITLE
[docs] Add warning to use Atomic for OpenShift

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ We're also extending our
 with these playbooks, so at the very least, it provides an example
 implementation of the `redhat-nfvpe.vm-spin` Ansible role.
 
+> **WARNING**
+>
+> With versions of OpenShift Origin > 3.7, it is recommended that you make use
+> of [Project Atomic](http://www.projectatomic.io/) images for the host
+> operating system, and use `containerized: true` for the OpenShift inventory
+> configuration (passed to OpenShift Origin, not this repository). See
+> [Installing OpenShift using CentOS Atomic Host](docs/openshift-atomic.md) for
+> more information.
+
 ## Usage
 
 ### Quickstart


### PR DESCRIPTION
In versions greater than OpenShift 3.7, the RPM installation method
is no longer an option, and you should use containerized: true for
the OpenShift installation. Because of this, it is strongly
recommended that you make use of Project Atomic, which is a better
base for those versions of OpenShift Origin.

Closes #29