### PR TITLE
Add 3 node (1 master, 2 nodes) example with storage

### DIFF
--- a/inventory/examples/3node/inventory.yml
+++ b/inventory/examples/3node/inventory.yml
@@ -1,0 +1,71 @@
+# vim: set ft=yaml shiftwidth=2 tabstop=2 expandtab :
+openshift-master ansible_host=192.168.3.76
+openshift-node-1 ansible_host=192.168.3.77
+openshift-node-2 ansible_host=192.168.3.78
+
+[OSEv3:children]
+masters
+etcd
+glusterfs
+
+[OSEv3:vars]
+ansible_become=yes
+debug_level=4
+
+# storage
+openshift_storage_glusterfs_namespace=glusterfs
+openshift_storage_glusterfs_name=storage
+openshift_storage_glusterfs_storageclass_default=true
+
+# service broker
+openshift_enable_service_catalog=true
+openshift_service_catalog_image_version=v3.9
+
+# main setup
+openshift_disable_check=disk_availability,memory_availability,docker_image_availability
+openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
+openshift_deployment_type=origin
+openshift_release=v3.9
+enable_excluders=false
+openshift_clock_enabled=true
+
+
+# hostname setup
+openshift_hostname_check=true
+openshift_master_default_subdomain=apps.openshift.nfvpe.site
+openshift_master_cluster_hostname=master.openshift.nfvpe.site
+openshift_master_cluster_public_hostname=console.openshift.nfvpe.site
+
+# ansible service broker
+ansible_service_broker_registry_user=<YOUR_DOCKERHUB_USERNAME>          # XXX: Change this
+ansible_service_broker_registry_password=<YOUR_DOCKERHUB_PASSWORD>      # XXX: Change this
+ansible_service_broker_registry_organization=ansibleplaybookbundle
+ansible_service_broker_registry_whitelist=[".*-apb$"]
+ansible_service_broker_local_registry_whitelist=[".*"]
+
+[master]
+openshift-master
+
+[masters]
+openshift-master
+
+[etcd]
+openshift-master
+
+[nodes]
+openshift-master openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+openshift-node-[1:2] openshift_node_labels="{'zone': 'default'}"
+
+[glusterfs]
+openshift-master
+openshift-node-[1:2]
+
+[glusterfs:vars]
+glusterfs_devices=[ "/dev/vdb" ]
+r_openshift_storage_glusterfs_use_firewalld=false
+r_openshift_storage_glusterfs_firewall_enabled=true
+openshift_storage_glusterfs_timeout=900
+openshift_storage_glusterfs_wipe=true
+
+[all:vars]
+ansible_user=centos

--- a/inventory/examples/3node/vars.yml
+++ b/inventory/examples/3node/vars.yml
@@ -1,0 +1,41 @@
+# vim: set tabstop=2 shiftwidth=2 ft=yaml :
+---
+centos_genericcloud_url: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
+image_destination_name: CentOS-7-x86_64-GenericCloud.qcow2
+host_type: "centos"
+images_directory: /home/images/3node
+spare_disk_location: /home/images/3node
+ssh_proxy_user: root
+ssh_proxy_host: virthost
+vm_ssh_key_path: /home/lmadsen/.ssh/3node
+
+# network configuration for bridged network on virtual machine
+bridge_networking: true
+bridge_name: br1
+bridge_physical_nic: "enp3s0"
+bridge_network_name: "br1"
+bridge_network_cidr: 192.168.3.0/24
+domain_name: openshift.nfvpe.site
+
+# network configuration for spinup.sh in redhat-nfvpe.vm-spinup role
+system_network: 192.168.3.0
+system_netmask: 255.255.255.0
+system_broadcast: 192.168.3.255
+system_gateway: 192.168.3.1
+system_nameservers: 192.168.3.1
+system_dns_search: openshift.nfvpe.site
+
+# list of virtual machines to create
+virtual_machines:
+  - name: openshift-master
+    node_type: master
+    system_ram_mb: 4096
+    static_ip: 192.168.3.76
+  - name: openshift-node-1
+    node_type: node
+    system_ram_mb: 8192
+    static_ip: 192.168.3.77
+  - name: openshift-node-2
+    node_type: node
+    system_ram_mb: 8192
+    static_ip: 192.168.3.78


### PR DESCRIPTION
Provides 3 nodes (single master, two nodes) for OpenShift with storage and
catalog deployment for AutomationBroker.io